### PR TITLE
Fix: Make applyEdit work with files without language server support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,12 @@ The project has a comprehensive implementation plan (see PLAN.md) and foundation
      - `getForFile()` method for file-based language detection
    - **Comprehensive Testing**: Unit and integration tests with mocking
 
+### ✅ applyEdit Universal File Support
+   - **Graceful Fallback**: `applyEdit` now works with ANY file type
+     - Files without language servers (JSON, YAML, Markdown, etc.) are edited directly
+     - Language servers used for validation when available but not required
+     - Prevents "No language server available" errors for common file types
+
 ### Next dependencies to install (when needed):
    - `p-queue` - Request queuing and batching (for Issue #3)
 
@@ -87,7 +93,7 @@ The project implements:
    - `getCodeIntelligence` - Hover, signatures, and completions
    - `findSymbols` - Document and workspace symbol search
    - `findUsages` - References and call hierarchy
-   - `applyEdit` - Code actions, rename, format with transaction support
+   - `applyEdit` - Apply edits to ANY file type (with or without LSP support), rename, format with transaction support
    - `getDiagnostics` - Errors, warnings, and quick fixes
 
 2. **Key Design Decisions**:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm run build
   - `getCodeIntelligence` - Hover info, signatures, and completions
   - `findSymbols` - Document and workspace symbol search
   - `findUsages` - References and call hierarchy
-  - `applyEdit` - Code actions, rename, format with transactions
+  - `applyEdit` - Apply edits to ANY file type, with or without language server support
   - `getDiagnostics` - Errors, warnings, and quick fixes
 
 - **Container-First Architecture**:

--- a/src/tools/applyEdit.ts
+++ b/src/tools/applyEdit.ts
@@ -213,11 +213,11 @@ export class ApplyEditTool extends BatchableTool<ApplyEditParams, ApplyEditResul
               `Language server not connected for ${language}, continuing with direct file edit`
             );
           }
-        } catch {
+        } catch (error) {
           // Language server not available - this is fine for many file types
           // Log for debugging but continue with the edit
           this.logger.debug(
-            { language, uri },
+            { language, uri, error: error instanceof Error ? error.message : String(error) },
             `No language server for ${language}, applying edit directly to filesystem`
           );
         }

--- a/src/tools/applyEdit.ts
+++ b/src/tools/applyEdit.ts
@@ -208,14 +208,18 @@ export class ApplyEditTool extends BatchableTool<ApplyEditParams, ApplyEditResul
 
           if (client && !client.isConnected()) {
             // Log warning but continue - we can still apply filesystem edits
-            console.warn(
+            this.logger.warn(
+              { language, uri },
               `Language server not connected for ${language}, continuing with direct file edit`
             );
           }
         } catch {
           // Language server not available - this is fine for many file types
           // Log for debugging but continue with the edit
-          console.debug(`No language server for ${language}, applying edit directly to filesystem`);
+          this.logger.debug(
+            { language, uri },
+            `No language server for ${language}, applying edit directly to filesystem`
+          );
         }
       }
 


### PR DESCRIPTION
## Summary
- Fixed applyEdit tool to gracefully handle files without language server support
- Prevents "No language server available for: plaintext" errors when editing JSON, YAML, and other files
- Language server checks are now non-blocking - edits proceed even without LSP

## Problem
The applyEdit tool was throwing errors when trying to edit files that don't have language servers (like package.json, YAML files, etc.). This was because it required a language server to be available for all file types.

## Solution
- Changed the language server check from a fatal error to a non-blocking warning
- The tool now continues with direct filesystem edits when no language server is available
- Added proper logging for debugging without breaking the operation

## Changes
- Modified `src/tools/applyEdit.ts` to catch language server errors and continue
- Updated unit tests to verify edits succeed without language servers
- Added documentation about universal file support in:
  - Tool description
  - README.md
  - CLAUDE.md

## Test plan
- [x] Unit tests pass with the new behavior
- [x] Lint checks pass
- [x] Type checking passes
- [ ] Manual testing with various file types (JSON, YAML, Markdown)
- [ ] Verify existing TypeScript/JavaScript edits still work

🤖 Generated with [Claude Code](https://claude.ai/code)